### PR TITLE
fix: removed flashbang when loading page in dark mode

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -13,6 +13,29 @@
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="theme-color" content="#00000000" />
         <link rel="icon" href="%sveltekit.assets%/favicon.svg" />
+        <script>
+            try {
+                if (!("theme" in localStorage)) {
+                    localStorage.theme = window.matchMedia(
+                        "(prefers-color-scheme: dark)",
+                    ).matches
+                        ? "dark"
+                        : "light";
+                }
+
+                document
+                    .querySelector("html")
+                    .classList.add(`${localStorage.theme}`);
+                document
+                    .querySelector('meta[name="theme-color"]')
+                    .setAttribute(
+                        "content",
+                        localStorage.theme === "light" ? "#ffffff" : "#000000",
+                    );
+            } catch (e) {
+                console.error(e);
+            }
+        </script>
         %sveltekit.head%
     </head>
 
@@ -23,28 +46,4 @@
         <!-- class="bg-cover w-full min-h-screen bg-no-repeat bg-fixed" style="background-image: url(/src/assets/bg.png)" -->
         <div style="display: contents">%sveltekit.body%</div>
     </body>
-
-    <script>
-        try {
-            if (!("theme" in localStorage)) {
-                localStorage.theme = window.matchMedia(
-                    "(prefers-color-scheme: dark)",
-                ).matches
-                    ? "dark"
-                    : "light";
-            }
-
-            document
-                .querySelector("html")
-                .classList.add(`${localStorage.theme}`);
-            document
-                .querySelector('meta[name="theme-color"]')
-                .setAttribute(
-                    "content",
-                    localStorage.theme === "light" ? "#ffffff" : "#000000",
-                );
-        } catch (e) {
-            console.error(e);
-        }
-    </script>
 </html>


### PR DESCRIPTION
hey there! when the website loads with the intent of being in light mode, its fine but for dark mode, its completely white for a second or two until the javascript which checks for the preferences is run, until which, its a pure white screen 😭


https://github.com/user-attachments/assets/e8b0d627-45ad-4b82-98c0-32420098c6d2

